### PR TITLE
Add new dependencies for Puppeteer.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,10 @@
 FROM circleci/android:api-26-node8-alpha
-RUN sudo apt-get update && sudo apt-get install gradle -y
+RUN sudo apt-get update && sudo apt-get install -y \
+  gradle gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \
+  libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 \
+  libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 \
+  libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+  libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
+  libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+  fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
+  wget


### PR DESCRIPTION
This relates to the changes introduced in meteor/meteor#9814, particularly
the new Aptitude packages necessary to support the Puppeteer functionality,
as seen in https://github.com/toinevk/meteor/commit/ee47ff56d87a9ea.

By utilizing this CircleCI image that we've already needed to implement for
Android builds, we'll be able to speed up the initial CircleCI start times
by avoiding the need to install the packages from apt sources on every
build.