### PR TITLE
Upgrade circleci image to node 22 and android 35

### DIFF
--- a/DockerfileNode20
+++ b/DockerfileNode20
@@ -23,11 +23,10 @@ RUN sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/j
 # Installing gradle
 RUN curl -s "https://get.sdkman.io" | bash && \
     source "/home/circleci/.sdkman/bin/sdkman-init.sh" && \
-    sdk install gradle 8.13
+    sdk install gradle 8.7
 
 
 RUN . ~/.nvm/nvm.sh && source ~/.bashrc && nvm install $NODE_VERSION  \
   && nvm use $NODE_VERSION \
   && nvm alias default $NODE_VERSION \
   && n=$(which node);n=${n%/bin/node}; chmod -R 755 $n/bin/*; sudo cp -r $n/{bin,lib,share} /usr/local; rm -rf /home/circleci/project/*
-  

--- a/DockerfileNode20
+++ b/DockerfileNode20
@@ -1,6 +1,6 @@
-FROM cimg/android:2024.08.1-node
+FROM cimg/android:2025.04.1-node
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-ENV NODE_VERSION 20.17.0
+ENV NODE_VERSION 22.17.0
 ENV NVM_DIR ~/.nvm/
 
 RUN sudo apt-get update && sudo apt-get install -y \
@@ -23,7 +23,7 @@ RUN sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/j
 # Installing gradle
 RUN curl -s "https://get.sdkman.io" | bash && \
     source "/home/circleci/.sdkman/bin/sdkman-init.sh" && \
-    sdk install gradle 8.7
+    sdk install gradle 8.13
 
 
 RUN . ~/.nvm/nvm.sh && source ~/.bashrc && nvm install $NODE_VERSION  \


### PR DESCRIPTION
<!-- OSS-816 -->

This PR ensures to upgrade the circleci image used for meteor/meteor checks to use a proper new version to [pass the tests on upgrade Cordova 14](https://github.com/meteor/meteor/pull/13837).